### PR TITLE
Add compatibility option 

### DIFF
--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -85,7 +85,6 @@ runs:
         conan profile update settings.compiler.libcxx=${{ inputs.conan-libcxx-version}} action_build
         conan profile update settings.build_type=${{ inputs.conan-build-type }} action_build
         conan profile update options.shared=True action_build
-        conan profile update options.fPIC=True action_build
         conan profile show action_build
 
         mkdir _build

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -133,8 +133,6 @@ runs:
         fi
         echo "Display package recipes"
         conan search $CONAN_PACKAGE_NAME
-
-        export CONAN_USER_HOME=`pwd`/_conan
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
         export CONAN_PACKAGE_VERSION=`conan inspect --raw version conanfile.py`
         echo "Packages in cache: "

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -116,6 +116,7 @@ runs:
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
         
         if [[ $compatibility_found == compatibility ]]; then
+          echo "Configuration for profile compatibility"
           cat `conan config home`/profiles/compatibility
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build -pr compatibility
         else

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -109,11 +109,11 @@ runs:
 
         mkdir _build
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
-        conan profile list | grep compatibility
-        if [ $? -ne 0]; then
-          conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build
-        else
+        
+        if [ conan profile list | grep compatibility ]; then
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build -pr compatibility
+        else
+          conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build
         fi
 
       shell: bash

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -97,7 +97,7 @@ runs:
         echo "compatibility_found=$compatibility_found" >> $GITHUB_ENV
       shell: bash
 
-    - name: Build with conan 
+    - name: Setup profiles 
       run: |   
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
         conan profile new action_build
@@ -113,6 +113,15 @@ runs:
         conan profile show action_build
 
         mkdir _build
+
+      shell: bash
+      env:
+        BUILD_SHARED: True
+        CC: ${{inputs.conan-cc}}
+        CXX: ${{inputs.conan-cxx}}
+
+    - name: Build & upload to artifactory with conan
+      run: |
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
         
         if [[ $compatibility_found == compatibility ]]; then
@@ -125,16 +134,6 @@ runs:
         echo "Display package recipes"
         conan search $CONAN_PACKAGE_NAME
 
-      shell: bash
-      env:
-        BUILD_SHARED: True
-        CONAN_UPLOAD: https://lkeb-artifactory.lumc.nl/artifactory/api/conan/conan-local
-        CONAN_LKEB_ARTIFACTORY: lkeb-artifactory
-        CC: ${{inputs.conan-cc}}
-        CXX: ${{inputs.conan-cxx}}
-
-    - name: Upload to artifactory with conan
-      run: |
         export CONAN_USER_HOME=`pwd`/_conan
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
         export CONAN_PACKAGE_VERSION=`conan inspect --raw version conanfile.py`

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -110,7 +110,8 @@ runs:
         mkdir _build
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
         
-        if [ conan profile list | grep compatibility ]; then
+        compatibility_found = `conan profile list | grep -E 'compatibility' | wc -l`
+        if [[ $compatibility_found == 1 ]]; then
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build -pr compatibility
         else
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -140,7 +140,7 @@ runs:
         echo "Packages in cache: "
         conan search
         echo "About to upload $CONAN_PACKAGE_NAME/$CONAN_PACKAGE_VERSION to $CONAN_LKEB_ARTIFACTORY"
-        conan upload --all --force --confirm -r $CONAN_LKEB_ARTIFACTORY $CONAN_PACKAGE_NAME/$CONAN_PACKAGE_VERSION
+        conan upload --all --force --confirm -r $CONAN_LKEB_ARTIFACTORY $CONAN_PACKAGE_NAME/*
 
       shell: bash
       env:

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -82,7 +82,7 @@ runs:
     - name: Get compatibility logic
       uses: actions/checkout@v4
       with:
-        repository: ManivaultStudio/gihub-actions
+        repository: ManiVaultStudio/gihub-actions
         path: github-actions
         ref: compatibility
 

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -73,6 +73,11 @@ runs:
         conan remote add $CONAN_LKEB_ARTIFACTORY $CONAN_UPLOAD
         echo Add upload user
         conan user -r $CONAN_LKEB_ARTIFACTORY -p ${{ inputs.conan-password }} ${{ inputs.conan-user }}
+      shell: bash
+      env:
+        BUILD_SHARED: True
+        CONAN_UPLOAD: https://lkeb-artifactory.lumc.nl/artifactory/api/conan/conan-local
+        CONAN_LKEB_ARTIFACTORY: lkeb-artifactory
 
     - name: Get compatibility logic
       uses: actions/checkout@v4

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -135,6 +135,9 @@ runs:
       run: |
         export CONAN_USER_HOME=`pwd`/_conan
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
+        echo "Packages in cache: "
+        conan search *
+        echo "About to upload $CONAN_PACKAGE_NAME/* to $CONAN_LKEB_ARTIFACTORY"
         conan upload --all --force --confirm -r $CONAN_LKEB_ARTIFACTORY $CONAN_PACKAGE_NAME/*
 
       shell: bash

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -87,11 +87,12 @@ runs:
         ref: compatibility
 
     - name: Make compatibility profile (if needed) 
-      run:
+      run: |
         python github-actions/python/get_compatibility_list.py ${{ inputs.conan-build-os }} ${{ inputs.conan-compiler }} ${{ inputs.conan-compiler-version }}
       shell: bash
 
-    - name: Build with conan   
+    - name: Build with conan 
+      run: |   
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
         conan profile new action_build
         conan profile update settings.os=${{ inputs.conan-build-os }} action_build

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -110,8 +110,8 @@ runs:
         mkdir _build
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
         
-        compatibility_found=`conan profile list | grep -E 'compatibility' | wc -l`
-        if [[ $compatibility_found == 1 ]]; then
+        compatibility_found=`conan profile list | (grep -E 'compatibility' || true)`
+        if [[ $compatibility_found == compatibility ]]; then
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build -pr compatibility
         else
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -87,9 +87,14 @@ runs:
         path: github-actions
         fetch-depth: 1
 
+# Continue on error is to suppress grep 
+# exit code when compatibility is not present
     - name: Make compatibility profile (if needed) 
+      continue-on-error: true
       run: |
         python github-actions/python/get_compatibility_list.py ${{ inputs.conan-build-os }} ${{ inputs.conan-compiler }} ${{ inputs.conan-compiler-version }}
+        compatibility_found=`conan profile list | (grep -E 'compatibility' || true)`
+        echo "compatibility_found=$compatibility_found" >> $GITHUB_ENV
       shell: bash
 
     - name: Build with conan 
@@ -110,7 +115,6 @@ runs:
         mkdir _build
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
         
-        compatibility_found=`conan profile list | (grep -E 'compatibility' || true)`
         if [[ $compatibility_found == compatibility ]]; then
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build -pr compatibility
         else

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -66,15 +66,28 @@ runs:
       env:
         CONAN_PEM: ${{ inputs.conan-pem }}
 
-    - name: Build with conan
+    - name: Setup conan
       run: |
         export CONAN_USER_HOME=`pwd`/_conan
         echo Add LKEB artifactory as remote
         conan remote add $CONAN_LKEB_ARTIFACTORY $CONAN_UPLOAD
         echo Add upload user
         conan user -r $CONAN_LKEB_ARTIFACTORY -p ${{ inputs.conan-password }} ${{ inputs.conan-user }}
-        export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
 
+    - name: Get compatibility logic
+      uses: actions/checkout@v4
+      with:
+        repository: ManivaultStudio/gihub-actions
+        path: github-actions
+        ref: compatibility
+
+    - name: Make compatibility profile (if needed) 
+      run:
+        python github-actions/python/get_compatibility_list.py ${{ inputs.conan-build-os }} ${{ inputs.conan-compiler }} ${{ inputs.conan-compiler-version }}
+      shell: bash
+
+    - name: Build with conan   
+        export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
         conan profile new action_build
         conan profile update settings.os=${{ inputs.conan-build-os }} action_build
         conan profile update settings.os_build=${{ inputs.conan-build-os }} action_build
@@ -89,7 +102,12 @@ runs:
 
         mkdir _build
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
-        conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build
+        conan profile list | grep compatibility
+        if [ $? -ne 0]; then
+          conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build
+        else
+          conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build -pr compatibility
+        fi
 
       shell: bash
       env:

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -83,8 +83,9 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: ManiVaultStudio/gihub-actions
-        path: github-actions
         ref: compatibility
+        path: github-actions
+        fetch-depth: 1
 
     - name: Make compatibility profile (if needed) 
       run: |

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -82,7 +82,7 @@ runs:
     - name: Get compatibility logic
       uses: actions/checkout@v4
       with:
-        repository: ManiVaultStudio/gihub-actions
+        repository: ManiVaultStudio/github-actions
         ref: compatibility
         path: github-actions
         fetch-depth: 1

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -136,7 +136,7 @@ runs:
         export CONAN_USER_HOME=`pwd`/_conan
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
         echo "Packages in cache: "
-        conan search *
+        conan search
         echo "About to upload $CONAN_PACKAGE_NAME/* to $CONAN_LKEB_ARTIFACTORY"
         conan upload --all --force --confirm -r $CONAN_LKEB_ARTIFACTORY $CONAN_PACKAGE_NAME/*
 

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -122,6 +122,8 @@ runs:
         else
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build
         fi
+        echo "Display package recipes"
+        conan search $CONAN_PACKAGE_NAME
 
       shell: bash
       env:
@@ -135,10 +137,11 @@ runs:
       run: |
         export CONAN_USER_HOME=`pwd`/_conan
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
+        export CONAN_PACKAGE_VERSION=`conan inspect --raw version conanfile.py`
         echo "Packages in cache: "
         conan search
-        echo "About to upload $CONAN_PACKAGE_NAME/* to $CONAN_LKEB_ARTIFACTORY"
-        conan upload --all --force --confirm -r $CONAN_LKEB_ARTIFACTORY $CONAN_PACKAGE_NAME/*
+        echo "About to upload $CONAN_PACKAGE_NAME/$CONAN_PACKAGE_VERSION to $CONAN_LKEB_ARTIFACTORY"
+        conan upload --all --force --confirm -r $CONAN_LKEB_ARTIFACTORY $CONAN_PACKAGE_NAME/$CONAN_PACKAGE_VERSION
 
       shell: bash
       env:

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -116,6 +116,7 @@ runs:
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
         
         if [[ $compatibility_found == compatibility ]]; then
+          cat `conan config home`/profiles/compatibility
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build -pr compatibility
         else
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -110,7 +110,7 @@ runs:
         mkdir _build
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
         
-        compatibility_found = `conan profile list | grep -E 'compatibility' | wc -l`
+        compatibility_found=`conan profile list | grep -E 'compatibility' | wc -l`
         if [[ $compatibility_found == 1 ]]; then
           conan create . lkeb/stable  -pr:b=action_build -pr:h=action_build -pr compatibility
         else

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -92,6 +92,7 @@ runs:
     - name: Make compatibility profile (if needed) 
       continue-on-error: true
       run: |
+        export CONAN_USER_HOME=`pwd`/_conan
         python github-actions/python/get_compatibility_list.py ${{ inputs.conan-build-os }} ${{ inputs.conan-compiler }} ${{ inputs.conan-compiler-version }}
         compatibility_found=`conan profile list | (grep -E 'compatibility' || true)`
         echo "compatibility_found=$compatibility_found" >> $GITHUB_ENV
@@ -99,6 +100,7 @@ runs:
 
     - name: Setup profiles 
       run: |   
+        export CONAN_USER_HOME=`pwd`/_conan
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
         conan profile new action_build
         conan profile update settings.os=${{ inputs.conan-build-os }} action_build
@@ -122,6 +124,7 @@ runs:
 
     - name: Build & upload to artifactory with conan
       run: |
+        export CONAN_USER_HOME=`pwd`/_conan
         if [ -d "./external/conan-recipes" ]; then conan export ./external/conan-recipes/bundle_package bundleutils/0.1@lkeb/stable; fi
         
         if [[ $compatibility_found == compatibility ]]; then

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -138,8 +138,6 @@ runs:
         conan search $CONAN_PACKAGE_NAME
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
         export CONAN_PACKAGE_VERSION=`conan inspect --raw version conanfile.py`
-        echo "Packages in cache: "
-        conan search
         echo "About to upload $CONAN_PACKAGE_NAME/$CONAN_PACKAGE_VERSION to $CONAN_LKEB_ARTIFACTORY"
         conan upload --all --force --confirm -r $CONAN_LKEB_ARTIFACTORY $CONAN_PACKAGE_NAME/*
 

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -85,6 +85,7 @@ runs:
         conan profile update settings.compiler.libcxx=${{ inputs.conan-libcxx-version}} action_build
         conan profile update settings.build_type=${{ inputs.conan-build-type }} action_build
         conan profile update options.shared=True action_build
+        conan profile update options.fPIC=True action_build
         conan profile show action_build
 
         mkdir _build

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -7,7 +7,7 @@ from subprocess import run
 from inspect import isfunction
 
 def call_func(full_module_name, func_name, *argv):
-    module = importlib.import_module(full_module_name, package=__name__)
+    module = importlib.import_module(full_module_name)
     for attribute_name in dir(module):
         attribute = getattr(module, attribute_name)
         if isfunction(attribute) and attribute_name == func_name:

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -11,10 +11,10 @@ def call_func(full_module_name, func_name, *argv):
     print(f"module: {full_module_name} contents: {dir(module)}")
     for attribute_name in dir(module):
         attribute = getattr(module, attribute_name)
+        print(f"checking {attribute}")
         if isfunction(attribute) and attribute_name == func_name:
-            attribute(*argv)
-        else:
-            return None
+            return attribute(*argv)
+    return None
 
 def get_list_from_conanfile(args):
     # the information is in the conanfile if that file

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     list = get_list_from_conanfile(args)
     if list:
-        print(f"compability: {list})
+        print(f"compability: {list}")
         run(['conan', 'profile', 'new', 'compatibility' ])
         for line in list:
             run(['conan', 'profile', 'update', f'settings.{line}', 'compatibility'])

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -3,6 +3,7 @@ import importlib
 import os
 import sys
 from pathlib import Path
+from subprocess import run
 
 def get_list_from_conanfile(args):
     # the information is in the conanfile if that file
@@ -17,7 +18,7 @@ def get_list_from_conanfile(args):
     print(f"{dir(module)}")
     if "compatibility" in dir(module):
         return (module.compatibility(args.os, args.compiler, args.compiler_version))
-    return ""
+    return None
 
 
 
@@ -27,4 +28,8 @@ if __name__ == "__main__":
     parser.add_argument("compiler", type=str, help="The compiler target of the build")
     parser.add_argument("compiler_version", type=str, help="The compiler-version target of the build")
     args = parser.parse_args()
-    print(get_list_from_conanfile(args))
+    list = get_list_from_conanfile(args)
+    if list:
+        run(['conan', 'profile', 'new', 'compatibility' ])
+        for line in list:
+            run(['conan', 'profile', 'update', f'settings.{line}', 'compatibility'])

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -21,6 +21,7 @@ def get_list_from_conanfile(args):
     root_path = Path(os.getenv("GITHUB_WORKSPACE", "."))
     import_path = root_path.parents[0]
     print(f"import path {import_path}")
+    print(f"working dir {os.curdir}")
     call_func(f'{import_path}', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -23,7 +23,8 @@ def get_list_from_conanfile(args):
     print(f"import path {import_path}")
     print(f"working dir {Path(os.curdir).absolute()}")
     print(f"{os.listdir(os.curdir)}")
-    call_func(f'.conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
+    sys.path.insert(0, '')
+    call_func(f'conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -23,7 +23,7 @@ def get_list_from_conanfile(args):
     print(f"import path {import_path}")
     print(f"working dir {Path(os.curdir).absolute()}")
     sys.path.append("..")
-    call_func(f'..conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
+    call_func(f'conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -25,7 +25,7 @@ def get_list_from_conanfile(args):
     print(f"working dir {Path(os.curdir).absolute()}")
     print(f"{os.listdir(os.curdir)}")
     sys.path.insert(0, '')
-    call_func(f'conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
+    return call_func(f'conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -7,7 +7,7 @@ from subprocess import run
 from inspect import isfunction
 
 def call_func(full_module_name, func_name, *argv):
-    module = importlib.import_module(full_module_name)
+    module = importlib.import_module(full_module_name, package=None)
     for attribute_name in dir(module):
         attribute = getattr(module, attribute_name)
         if isfunction(attribute) and attribute_name == func_name:

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -34,6 +34,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
     list = get_list_from_conanfile(args)
     if list:
+        print(f"compability: {list})
         run(['conan', 'profile', 'new', 'compatibility' ])
         for line in list:
             run(['conan', 'profile', 'update', f'settings.{line}', 'compatibility'])
+        
+        run(['conan', 'profile', 'list'])
+    else:
+        print("No compatibility list")

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -22,7 +22,7 @@ def get_list_from_conanfile(args):
     import_path = root_path.parents[0]
     print(f"import path {import_path}")
     print(f"working dir {Path(os.curdir).absolute()}")
-    sys.path.append("..")
+    os.chdir('..') 
     call_func(f'conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -23,10 +23,7 @@ def get_list_from_conanfile(args):
     print(f"import path {import_path}")
     print(f"working dir {Path(os.curdir).absolute()}")
     print(f"{os.listdir(os.curdir)}")
-    os.chdir('..') 
-    print(f"working dir {Path(os.curdir).absolute()}")
-    print(f"{os.listdir(os.curdir)}")
-    call_func(f'conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
+    call_func(f'.conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -22,6 +22,7 @@ def get_list_from_conanfile(args):
     import_path = root_path.parents[0]
     print(f"import path {import_path}")
     print(f"working dir {Path(os.curdir).absolute()}")
+    sys.path.append("..")
     call_func(f'..conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -1,0 +1,30 @@
+import argparse
+import importlib 
+import os
+import sys
+from pathlib import Path
+
+def get_list_from_conanfile(args):
+    # the information is in the conanfile if that file
+    # contains a compatibility function
+    root_path = Path(os.getenv("GITHUB_WORKSPACE", "."))
+    import_path = root_path.parents[0]
+    print(f"import path {import_path}")
+    import_mod = root_path.parts[-1]
+    print(f"import mod {import_mod}")
+    sys.path.append(import_path)
+    module = importlib.import_module(import_mod, package=None)
+    print(f"{dir(module)}")
+    if "compatibility" in dir(module):
+        return (module.compatibility(args.os, args.compiler, args.compiler_version))
+    return ""
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("os", type=str, help="The os target of the build")
+    parser.add_argument("compiler", type=str, help="The compiler target of the build")
+    parser.add_argument("compiler_version", type=str, help="The compiler-version target of the build")
+    args = parser.parse_args()
+    print(get_list_from_conanfile(args))

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -21,7 +21,7 @@ def get_list_from_conanfile(args):
     root_path = Path(os.getenv("GITHUB_WORKSPACE", "."))
     import_path = root_path.parents[0]
     print(f"import path {import_path}")
-    print(f"working dir {os.curdir}")
+    print(f"working dir {Path(os.curdir).absolute()}")
     call_func(f'{import_path}', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     list = get_list_from_conanfile(args)
     if list:
-        print(f"compability: {list}")
+        print(f"compability: {','.join(list)}")
         run(['conan', 'profile', 'new', 'compatibility' ])
         for line in list:
             run(['conan', 'profile', 'update', f'settings.{line}', 'compatibility'])

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -4,6 +4,16 @@ import os
 import sys
 from pathlib import Path
 from subprocess import run
+from inspect import isfunction
+
+def call_func(full_module_name, func_name, *argv):
+    module = importlib.import_module(full_module_name)
+    for attribute_name in dir(module):
+        attribute = getattr(module, attribute_name)
+        if isfunction(attribute) and attribute_name == func_name:
+            attribute(*argv)
+        else:
+            return None
 
 def get_list_from_conanfile(args):
     # the information is in the conanfile if that file
@@ -11,16 +21,7 @@ def get_list_from_conanfile(args):
     root_path = Path(os.getenv("GITHUB_WORKSPACE", "."))
     import_path = root_path.parents[0]
     print(f"import path {import_path}")
-    import_mod = root_path.parts[-1]
-    print(f"import mod {import_mod}")
-    sys.path.append(import_path)
-    module = importlib.import_module(import_mod, package=None)
-    print(f"{dir(module)}")
-    if "compatibility" in dir(module):
-        return (module.compatibility(args.os, args.compiler, args.compiler_version))
-    return None
-
-
+    call_func(f'{import_path}', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -8,6 +8,7 @@ from inspect import isfunction
 
 def call_func(full_module_name, func_name, *argv):
     module = importlib.import_module(full_module_name)
+    print(f"module: {full_module_name} contents: {dir(module)}")
     for attribute_name in dir(module):
         attribute = getattr(module, attribute_name)
         if isfunction(attribute) and attribute_name == func_name:

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -23,6 +23,7 @@ def get_list_from_conanfile(args):
     print(f"import path {import_path}")
     print(f"working dir {Path(os.curdir).absolute()}")
     os.chdir('..') 
+    print(f"working dir {Path(os.curdir).absolute()}")
     call_func(f'conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -22,7 +22,7 @@ def get_list_from_conanfile(args):
     import_path = root_path.parents[0]
     print(f"import path {import_path}")
     print(f"working dir {Path(os.curdir).absolute()}")
-    call_func(f'{import_path}', 'compatibility', args.os, args.compiler, args.compiler_version)
+    call_func(f'..conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -7,7 +7,7 @@ from subprocess import run
 from inspect import isfunction
 
 def call_func(full_module_name, func_name, *argv):
-    module = importlib.import_module(full_module_name, package=None)
+    module = importlib.import_module(full_module_name, package=__name__)
     for attribute_name in dir(module):
         attribute = getattr(module, attribute_name)
         if isfunction(attribute) and attribute_name == func_name:

--- a/python/get_compatibility_list.py
+++ b/python/get_compatibility_list.py
@@ -22,8 +22,10 @@ def get_list_from_conanfile(args):
     import_path = root_path.parents[0]
     print(f"import path {import_path}")
     print(f"working dir {Path(os.curdir).absolute()}")
+    print(f"{os.listdir(os.curdir)}")
     os.chdir('..') 
     print(f"working dir {Path(os.curdir).absolute()}")
+    print(f"{os.listdir(os.curdir)}")
     call_func(f'conanfile', 'compatibility', args.os, args.compiler, args.compiler_version)
 
 if __name__ == "__main__":

--- a/python/test/__init__.py
+++ b/python/test/__init__.py
@@ -1,0 +1,1 @@
+from .conanfile import compatibility

--- a/python/test/conanfile.py
+++ b/python/test/conanfile.py
@@ -1,0 +1,6 @@
+def compatibility(os, compiler, compiler_version):
+    print(f"{os} {compiler} {compiler_version}")
+    return """hdf5/1.12.1:compiler.version=13
+lz4/1.9.2:compiler.version=13
+zlib/1.2.13:compiler.version=13
+"""

--- a/python/test/conanfile.py
+++ b/python/test/conanfile.py
@@ -1,6 +1,5 @@
 def compatibility(os, compiler, compiler_version):
     print(f"{os} {compiler} {compiler_version}")
-    return """hdf5/1.12.1:compiler.version=13
-lz4/1.9.2:compiler.version=13
-zlib/1.2.13:compiler.version=13
-"""
+    return ["hdf5/1.12.1:compiler.version=13",
+            "lz4/1.9.2:compiler.version=13",
+            "zlib/1.2.13:compiler.version=13"]


### PR DESCRIPTION
By providing a compatibility function at the top of the conanfile.py the user can give alternate versions of  dependencies that are compatible with the current build. Such a function might look like this: 

``` python
def compatibility(os, compiler, compiler_version):
    print(f"In citester compatibility function {os} {compiler} {compiler_version}")
    if os == "Macos" and compiler == "apple-clang" and bool(re.match("14.*", compiler_version)):  
        print("Compatibility match")
        return ["fmt/10.2.1:compiler.version=13"]
```

The initial goal of this functionality is provide a simple and maintainable mechanism to get around the lack of apple-clang 14 package on conan center. It can however to address the same issue with other os/compiler combinations.

A demo (using windows, linux and macos) can be found in the [citester repo](https://github.com/ManiVaultStudio/citester)  