### PR TITLE
Prepare CI Update 02 2025

### DIFF
--- a/CMakeSupport/InstallArtifactoryPackage.cmake
+++ b/CMakeSupport/InstallArtifactoryPackage.cmake
@@ -11,7 +11,7 @@ function(get_major_version full_version major_version)
         set(MSVC_140_VERSION 14)
         set(MSVC_141_VERSION 15)
         set(MSVC_142_VERSION 16)
-        set(MSVC_143_VERSION 16) # conan packages are compiled with VS2019 but fully compatible with VS2022
+        set(MSVC_143_VERSION 17)
         set(majver "${MSVC_${MSVC_TOOLSET_VERSION}_VERSION}")
     else()
         string(REPLACE "." ";" verlist ${full_version})

--- a/build_matrices/linux_gcc11.json
+++ b/build_matrices/linux_gcc11.json
@@ -8,6 +8,7 @@
         "build-cversion": "11",
         "build-config": "Release",
         "build-os": "Linux",
-        "build-libcxx": "libstdc++11"
+        "build-libcxx": "libstdc++11",
+        "build-arch": "x86_64"
     }
 ]

--- a/build_matrices/linux_gcc13.json
+++ b/build_matrices/linux_gcc13.json
@@ -1,0 +1,13 @@
+[ 
+    {
+        "name": "Linux_gcc13",
+        "os": "ubuntu-24.04",
+        "build-cc": "gcc",
+        "build-cxx": "g++",
+        "build-compiler": "gcc",
+        "build-cversion": "13",
+        "build-config": "Release",
+        "build-os": "Linux",
+        "build-libcxx": "libstdc++11"
+    }
+]

--- a/build_matrices/linux_gcc13.json
+++ b/build_matrices/linux_gcc13.json
@@ -8,6 +8,7 @@
         "build-cversion": "13",
         "build-config": "Release",
         "build-os": "Linux",
-        "build-libcxx": "libstdc++11"
+        "build-libcxx": "libstdc++11",
+        "build-arch": "x86_64"
     }
 ]

--- a/build_matrices/macos_code14.json
+++ b/build_matrices/macos_code14.json
@@ -7,6 +7,7 @@
         "build-config": "Release",
         "build-os": "Macos",
         "build-xcode-version": "14.3",
-        "build-libcxx": "libc++"
+        "build-libcxx": "libc++",
+        "build-arch": "x86_64"
     }
 ]

--- a/build_matrices/macos_code15.json
+++ b/build_matrices/macos_code15.json
@@ -1,0 +1,13 @@
+[ 
+    {
+        "name": "Macos_xcode15",
+        "os": "macos-14",
+        "build-compiler": "apple-clang",
+        "build-cversion": "15",
+        "build-config": "Release",
+        "build-os": "Macos",
+        "build-xcode-version": "15.4",
+        "build-libcxx": "libc++",
+        "build-arch": "armv8"
+    }
+]

--- a/build_matrices/macos_code16.json
+++ b/build_matrices/macos_code16.json
@@ -1,0 +1,13 @@
+[ 
+    {
+        "name": "Macos_xcode16",
+        "os": "macos-15",
+        "build-compiler": "apple-clang",
+        "build-cversion": "16",
+        "build-config": "Release",
+        "build-os": "Macos",
+        "build-xcode-version": "16.2",
+        "build-libcxx": "libc++",
+        "build-arch": "armv8"
+    }
+]

--- a/build_matrices/windows_2022.json
+++ b/build_matrices/windows_2022.json
@@ -1,0 +1,10 @@
+[ 
+    {
+        "name": "Windows-msvc2022",
+        "os": "windows-2022",
+        "compiler": "msvc-2022",
+        "build-cversion": "17",
+        "build-runtime": "MD",
+        "build-config": "Release"
+    }
+]

--- a/conan_linuxmac_build/README.md
+++ b/conan_linuxmac_build/README.md
@@ -5,7 +5,7 @@ This action supportss Linux or macOS
 ```
 inputs:
   conan-compiler:
-    description: 'gcc9 apple-clang'
+    description: 'gcc apple-clang'
     required: true
   conan-cc:
     description: 'gcc clang'
@@ -14,7 +14,7 @@ inputs:
     description: 'g++ clang++'
     required: true
   conan-compiler-version:
-    description: 'A number [gcc: 5 6 7 8 9 ] [clang: 39 40 50 60 7 8 9] [10.0]'
+    description: 'A number [gcc: 8 9 10 11 12 14] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10.0]'
     required: true
   conan-libcxx-version:
     description: 'Linux: libstdc++ or Macos: libc++ '

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -49,8 +49,7 @@ runs:
 
           sudo wget -q https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Ubuntu22.04-x64.tgz
           sudo tar -xf icu4c-73_2-Ubuntu22.04-x64.tgz
-          sudo find ./icu/usr/local/lib/ -name \"*.73*\" -print0 | xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
-          find ./icu/usr/local/lib/ -name "*.73*" -exec cp {} /usr/lib/x86_64-linux-gnu/ \;
+          sudo find ./icu/usr/local/lib/ -name "*.73*" -print0 | xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
           sudo rm -rf ./icu/
           sudo rm -rf icu4c-73_2-Ubuntu22.04-x64.tgz
         fi

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -36,14 +36,23 @@ inputs:
     description: "pass secrets.LKEB_CERT_CHAIN"
     required: true
 
+# Ubuntu 24.04 ships with libicu 74, see https://launchpad.net/ubuntu/+source/icu
+# but we some dependencies (qt 6.8) expect libicu 73, so we download is manually
 runs:
   using: "composite"
   steps:
     - name: Install conan & build configuration
       run: |
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-          sudo apt-get install ninja-build
-          sudo apt-get install libtbb-dev
+          sudo apt install -y ninja-build
+          sudo apt install -y libtbb-dev
+
+          sudo wget -q https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Ubuntu22.04-x64.tgz
+          sudo tar -xf icu4c-73_2-Ubuntu22.04-x64.tgz
+          sudo find ./icu/usr/local/lib/ -name \"*.73*\" -print0 | xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
+          find ./icu/usr/local/lib/ -name "*.73*" -exec cp {} /usr/lib/x86_64-linux-gnu/ \;
+          sudo rm -rf ./icu/
+          sudo rm -rf icu4c-73_2-Ubuntu22.04-x64.tgz
         fi
 
         if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -23,6 +23,9 @@ inputs:
   conan-build-os:
     description: "Linux or Macos"
     required: true
+  build-arch:
+    description: "either x86_64 or armv8 (for macos)"
+    required: true
   conan-user:
     description: "pass secrets.LKEB_ARTIFACTORY_USER"
     required: true
@@ -106,8 +109,8 @@ runs:
         conan profile new action_build
         conan profile update settings.os=${{ inputs.conan-build-os }} action_build
         conan profile update settings.os_build=${{ inputs.conan-build-os }} action_build
-        conan profile update settings.arch=x86_64 action_build
-        conan profile update settings.arch_build=x86_64 action_build
+        conan profile update settings.arch=${{ inputs.build-arch }} action_build
+        conan profile update settings.compiler=${{ inputs.conan-compiler }} action_build
         conan profile update settings.compiler=${{ inputs.conan-compiler }} action_build
         conan profile update settings.compiler.version=${{ inputs.conan-compiler-version }} action_build
         conan profile update settings.compiler.libcxx=${{ inputs.conan-libcxx-version}} action_build

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -49,7 +49,7 @@ runs:
         if [[ "$OSTYPE" == "darwin"* ]]; then
           brew install libomp
           export HOMEBREW_NO_AUTO_UPDATE=1
-        fidarwin
+        fi
         
         pip install conan~=1.66.0
         pip install gitpython

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -50,7 +50,7 @@ runs:
 
           sudo wget -q https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Ubuntu22.04-x64.tgz
           sudo tar -xvf icu4c-73_2-Ubuntu22.04-x64.tgz
-          sudo find ./icu/usr/local/lib/ -name "*.73*" -print0 | xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
+          sudo find ./icu/usr/local/lib/ -name "*.73*" -print0 | sudo xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
           sudo rm -rf ./icu/
           sudo rm -rf icu4c-73_2-Ubuntu22.04-x64.tgz
         fi

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Linux an
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-compiler:
-    description: "gcc9 apple-clang"
+    description: "gcc apple-clang"
     required: true
   conan-cc:
     description: "gcc clang"
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 8 9 10 11 12 13] [clang: 39 40 50 60 7 8 9 10 11 12 13] [10.0]"
+    description: "A number [gcc: 8 9 10 11 12 14] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -42,11 +42,13 @@ runs:
           sudo apt-get install ninja-build
           sudo apt-get install libtbb-dev
         fi
+
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          brew install libomp
+          export HOMEBREW_NO_AUTO_UPDATE=1
+        fidarwin
         
-        pip install wheel
-        pip install conan==1.66.0
-        pip install "markupsafe<2.1"
-        pip install -Iv cmake~=3.31.0
+        pip install conan~=1.66.0
         pip install gitpython
         pip install -v git+ssh://git@github.com/ManiVaultStudio/rulessupport.git@master
 
@@ -55,7 +57,6 @@ runs:
         cmake --version
         mkdir `pwd`/_conan
         export CONAN_USER_HOME=`pwd`/_conan
-        export HOMEBREW_NO_AUTO_UPDATE=1
         conan user
 
         echo Extend conan cacert.pem

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -44,9 +44,8 @@ runs:
         fi
         
         pip install wheel
-        pip install conan==1.62.0
+        pip install conan==1.66.0
         pip install "markupsafe<2.1"
-        pip install -Iv cmake~=3.27.0
         pip install gitpython
         pip install -v git+ssh://git@github.com/ManiVaultStudio/rulessupport.git@master
 

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -46,9 +46,10 @@ runs:
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
           sudo apt install -y ninja-build
           sudo apt install -y libtbb-dev
+          sudo apt install -y wget
 
           sudo wget -q https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Ubuntu22.04-x64.tgz
-          sudo tar -xf icu4c-73_2-Ubuntu22.04-x64.tgz
+          sudo tar -xvf icu4c-73_2-Ubuntu22.04-x64.tgz
           sudo find ./icu/usr/local/lib/ -name "*.73*" -print0 | xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
           sudo rm -rf ./icu/
           sudo rm -rf icu4c-73_2-Ubuntu22.04-x64.tgz

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -48,8 +48,9 @@ runs:
           sudo apt install -y libtbb-dev
           sudo apt install -y wget
 
+          echo "Downloading libicu73..."
           sudo wget -q https://github.com/unicode-org/icu/releases/download/release-73-2/icu4c-73_2-Ubuntu22.04-x64.tgz
-          sudo tar -xvf icu4c-73_2-Ubuntu22.04-x64.tgz
+          sudo tar -xf icu4c-73_2-Ubuntu22.04-x64.tgz
           sudo find ./icu/usr/local/lib/ -name "*.73*" -print0 | sudo xargs -0 cp -r -t /usr/lib/x86_64-linux-gnu/
           sudo rm -rf ./icu/
           sudo rm -rf icu4c-73_2-Ubuntu22.04-x64.tgz

--- a/conan_linuxmac_build/action.yml
+++ b/conan_linuxmac_build/action.yml
@@ -46,6 +46,7 @@ runs:
         pip install wheel
         pip install conan==1.66.0
         pip install "markupsafe<2.1"
+        pip install -Iv cmake~=3.31.0
         pip install gitpython
         pip install -v git+ssh://git@github.com/ManiVaultStudio/rulessupport.git@master
 

--- a/conan_windows_build/README.md
+++ b/conan_windows_build/README.md
@@ -7,7 +7,7 @@ Initial testing for Windows(2019) suggests that the chocolatey install of openss
 
 ```
   conan-visual-version:
-    description: 'MSVC version: 15, 16 represent msvc-2017 or msvc-2019'
+    description: 'MSVC version: 16, 17 represent msvc-2019 and msvc-2022'
     required: true
   conan-visual-runtime:
     description: 'MD or MDd'

--- a/conan_windows_build/action.yml
+++ b/conan_windows_build/action.yml
@@ -64,7 +64,6 @@ runs:
       run: |
         for /f "delims=" %%i in ('where cmake') do set CONAN_CMAKE_PROGRAM="%%i"
         set CONAN_USER_HOME=%cd%\_conan
-        set VS160COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools"
 
         echo Add LKEB artifactory as remote at URL: %CONAN_UPLOAD%
         conan remote add %CONAN_LKEB_ARTIFACTORY% %CONAN_UPLOAD%

--- a/conan_windows_build/action.yml
+++ b/conan_windows_build/action.yml
@@ -29,10 +29,7 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
-        pip install wheel
-        pip install conan==1.66.0
-        pip install "markupsafe<2.1"
-        pip install -Iv cmake~=3.31.0
+        pip install conan~=1.66.0
         pip install gitpython
         pip install git+ssh://git@github.com/ManiVaultStudio/rulessupport.git@master
 

--- a/conan_windows_build/action.yml
+++ b/conan_windows_build/action.yml
@@ -32,6 +32,7 @@ runs:
         pip install wheel
         pip install conan==1.66.0
         pip install "markupsafe<2.1"
+        pip install -Iv cmake~=3.31.0
         pip install gitpython
         pip install git+ssh://git@github.com/ManiVaultStudio/rulessupport.git@master
 

--- a/conan_windows_build/action.yml
+++ b/conan_windows_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Windows,
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-visual-version:
-    description: "MSVC version: 15, 16 represent msvc-2017 or msvc-2019"
+    description: "MSVC version: 16, 17 represent msvc-2019 and msvc-2022"
     required: true
   conan-visual-runtime:
     description: "MD or MDd"

--- a/conan_windows_build/action.yml
+++ b/conan_windows_build/action.yml
@@ -30,9 +30,8 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan==1.62.0
+        pip install conan==1.66.0
         pip install "markupsafe<2.1"
-        pip install -Iv "cmake>=3.17,<=3.27"
         pip install gitpython
         pip install git+ssh://git@github.com/ManiVaultStudio/rulessupport.git@master
 

--- a/matrix_setup/action.yml
+++ b/matrix_setup/action.yml
@@ -6,8 +6,12 @@ inputs:
       "A list of matrix ids to be used. Choose from
 
        - windows_2019 
+       - windows_2022 
        - linux_gcc11 
-       - macos_code14 
+       - linux_gcc13 
+       - macos_code14 [x86]
+       - macos_code15 [arm]
+       - macos_code16 [arm]
        
        If empty the list 'windows_2019 linux_gcc11 macos_code14' is used"
     default: 'windows_2019 linux_gcc11 macos_code14'

--- a/matrix_setup/action.yml
+++ b/matrix_setup/action.yml
@@ -29,7 +29,7 @@ runs:
     uses: actions/checkout@v4
     with:
       repository: ManiVaultStudio/github-actions
-      ref: main
+      ref: ${{ github.ref }}
       path: matrix
       fetch-depth: 1
 

--- a/matrix_setup/action.yml
+++ b/matrix_setup/action.yml
@@ -29,7 +29,7 @@ runs:
     uses: actions/checkout@v4
     with:
       repository: ManiVaultStudio/github-actions
-      ref: feature/PrepareCIUpdate022025
+      ref: main
       path: matrix
       fetch-depth: 1
 

--- a/matrix_setup/action.yml
+++ b/matrix_setup/action.yml
@@ -13,8 +13,8 @@ inputs:
        - macos_code15 [arm]
        - macos_code16 [arm]
        
-       If empty the list 'windows_2019 linux_gcc11 macos_code14' is used"
-    default: 'windows_2019 linux_gcc11 macos_code14'
+       If empty the default list is used"
+    default: 'windows_2022 linux_gcc13 macos_code14 macos_code16'
     required: false
 
 outputs:


### PR DESCRIPTION
- Update conan to `1.66` from `1.62` (allows for XCode 16)
- Do not install and use CMake with Python. This majorly interferes with finding and OpenMP and Apple's ARM platforms
- Use MSVC 2022 builds for packages downloaded from artifactory when building with MSVC 2022 (previously 2019-built packages were downloaded)
- Add several CI settings, for testing and later update. The defaults remain the same
- Do not default to `x86_64` on the "conan_linuxmac_build" but introduce the `build-arch` setting, which can also be `armv8`

Todo:
- [x] ~~`xcode-select`~~ (This can be done later)
- [x] ~~Update `aql_multi.json.in` with `RelWithDebugInfo`~~ (Not sure if needed)
- [x] Revert ref to `main`